### PR TITLE
Fixed a bug in the list where multiple items got a focus

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -22,13 +22,13 @@ export default Blits.Component('Item', {
     <Element
       w="$width"
       h="$height"
-      :color="$hasFocus ? '#fff' : '#888'"
+      :color="$isFocused ? '#fff' : '#888'"
       :effects="[{type: 'radius', props: {radius: $radius}}]"
     >
       <Text content="$item.label" color="#121212" size="$height/2" mount="0.5" x="$width/2" y="$height/2" />
     </Element>
   `,
-  props: ['item', 'width', 'height'],
+  props: ['item', 'width', 'height', 'isFocused'],
   state() {
     return {
       radius: 6,

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -32,6 +32,7 @@ export default Blits.Component('List', {
         :key="$item.id"
         width="$itemWidth"
         height="$itemHeight"
+        :isFocused="$focused === $index"
       />
     </Element>
   `,


### PR DESCRIPTION
If you hold the right arrow on the list multiple items get in a state of focused. I am not sure if this is the correct fix because it seems like `$hasFocus` is a property that belongs to a Blits component. 

This is what's happening when you hold the right arrow:

![image](https://github.com/user-attachments/assets/b201e772-d314-4650-8412-b186ea9a3c09)
